### PR TITLE
Implements Tab Depth

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "TabPad",
 	"description": "A Google Chrome extension to provide a 'scratchpad' for notes on the 'New Tab' page.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"chrome_url_overrides": {
 		"newtab": "/tabpad/tabpad.html"
 	},

--- a/tabpad/scripts/tabpad.js
+++ b/tabpad/scripts/tabpad.js
@@ -5,8 +5,6 @@ const SPECIAL = {
 	'Enter': '\n',
 };
 
-let IN_LIST = false;
-
 function saveChanges(ev) {
 	window.localStorage.setItem('tabpad', ev.target.innerText);
 }

--- a/tabpad/scripts/tabpad.js
+++ b/tabpad/scripts/tabpad.js
@@ -5,8 +5,26 @@ const SPECIAL = {
 	'Enter': '\n',
 };
 
+let IN_LIST = false;
+
 function saveChanges(ev) {
 	window.localStorage.setItem('tabpad', ev.target.innerText);
+}
+
+let strs = {};
+function getTabDepth(currentLine) {
+	let previous = editor.innerText.split(currentLine)[0];
+
+	let tabs = 0;
+	for ( let i = previous.length - 1; i >= 0; --i ) {
+		if ( previous[i] === '\t' ) {
+			tabs++;
+		} else {
+			break;
+		}
+	}
+
+	return tabs;
 }
 
 // Some keys, Tab and Enter, are special characters 
@@ -16,18 +34,54 @@ function handleSpecialKeys(ev) {
 	if ( ev.key in SPECIAL ) {
 		ev.preventDefault();
 
+		let tabs = 0; // counter for tab depth
+
 		let doc = editor.ownerDocument.defaultView;
 		let sel = doc.getSelection();
 		let range = sel.getRangeAt(0);
 
-		let specialNode = document.createTextNode(SPECIAL[ ev.key ]);
+		// Issue #1 - tab depth preservation
+		// If we hit enter on a line that has started with
+		// one or more tabs, create the newline, but include
+		// tabs to preserve the depth
+		let MagicInsert = '';
+		if ( ev.key === 'Enter' ) {
+			let startContainer = editor.ownerDocument.defaultView.getSelection().getRangeAt(0).startContainer; //.startContainer.textContent;
+			// check to see if the line is a textNode or a DOM node.
+			if ( startContainer.nodeType === 3 ) {
+				let tabCount = getTabDepth(startContainer.textContent);
+				if ( tabCount ) {
+					MagicInsert = SPECIAL.Tab.repeat(tabCount);
+				}
+				let textContent = startContainer.textContent;
+				let len = textContent.length;
+				for ( let i = 0; i < len; ++i ) {
+					if ( textContent[i] === '\t' ) {
+						tabs++;
+						MagicInsert += '\t';
+					} else if ( textContent[i] === '-' ) {
+						MagicInsert += '- ';
+					} else if ( textContent[i] === '\n' ) {
+						// if we've created a text node previously, and our selection
+						// has slurped in the newline, ignore it, but keep processing the
+						// rest of the string.
+						continue;
+					} else {
+						// if we find anything other than a tab, stop the loop
+						break;
+					}
+				}
+			}
+		}
+
+		let specialNode = document.createTextNode(`${SPECIAL[ ev.key ]}${MagicInsert}`);
 		range.insertNode(specialNode);
 
 		range.setStartAfter(specialNode);
 		range.setEndAfter(specialNode); 
 		sel.removeAllRanges();
 		sel.addRange(range);
-		
+
 		// now that we've properly handled tabs, save changes
 		saveChanges(ev);
 	}


### PR DESCRIPTION
Saves tab depth at the cursor and does a tiny bit of magic to keep you in a "list" state if you're working on a Markdown-style list:

- like this
- and this
- and that

This was painful, and it's getting to the point where I'll need to introduce a formal parser to continue adding features. Good enough for now.